### PR TITLE
add license to gemspec

### DIFF
--- a/lambda_deployment.gemspec
+++ b/lambda_deployment.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Zendesk CloudOps']
   s.files       = Dir.glob('{bin,lib}/**/*') + ['README.md']
   s.homepage    = 'https://github.com/zendesk/lambda_deployment'
+  s.licenses    = ['Apache-2.0']
   s.executables = ['lambda_deploy']
 
   s.add_runtime_dependency 'aws-sdk-core', '~> 2'


### PR DESCRIPTION
Add license to gemspec so it is set on rubygems.org

@grosser 
@ashmckenzie 
@zendesk/cloudops 