### PR TITLE
lambda aliases must start with a number

### DIFF
--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -15,8 +15,7 @@ module LambdaDeployment
     end
 
     def alias_name
-      tag = ENV.fetch('TAG', nil)
-      tag.match(/\d.*/)[0] unless tag.nil?
+      ENV['TAG'].to_s[/\d.*/]
     end
 
     private

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -15,7 +15,8 @@ module LambdaDeployment
     end
 
     def alias_name
-      ENV.fetch('TAG', nil)
+      tag = ENV.fetch('TAG', nil)
+      tag.match(/\d.*/)[0] unless tag.nil?
     end
 
     private

--- a/spec/lambda_deployment/lambda/deploy_spec.rb
+++ b/spec/lambda_deployment/lambda/deploy_spec.rb
@@ -34,7 +34,7 @@ describe LambdaDeployment::Lambda::Deploy do
       ).and_return(OpenStruct.new(version: 1))
       expect_any_instance_of(Aws::Lambda::Client).to receive(:create_alias).with(
         function_name: 'lambda-deploy',
-        name: 'v123',
+        name: '123',
         function_version: 1
       ).and_return(nil)
       described_class.new(@config).run
@@ -48,12 +48,12 @@ describe LambdaDeployment::Lambda::Deploy do
       ).and_return(OpenStruct.new(version: 1))
       expect_any_instance_of(Aws::Lambda::Client).to receive(:create_alias).with(
         function_name: 'lambda-deploy',
-        name: 'v123',
+        name: '123',
         function_version: 1
       ).and_raise(Aws::Lambda::Errors::ResourceConflictException.new(1, 2))
       expect_any_instance_of(Aws::Lambda::Client).to receive(:update_alias).with(
         function_name: 'lambda-deploy',
-        name: 'v123',
+        name: '123',
         function_version: 1
       )
       described_class.new(@config).run

--- a/spec/lambda_deployment/lambda/release_spec.rb
+++ b/spec/lambda_deployment/lambda/release_spec.rb
@@ -28,7 +28,7 @@ describe LambdaDeployment::Lambda::Release do
     it 'updates the production alias to the specified tag' do
       expect_any_instance_of(Aws::Lambda::Client).to receive(:get_alias).with(
         function_name: 'lambda-deploy',
-        name: 'v123'
+        name: '123'
       ).and_return(OpenStruct.new(function_version: 1))
       stub_update_alias(function_name: 'lambda-deploy', name: 'production', function_version: 1)
       described_class.new(@config).run


### PR DESCRIPTION
Lambda aliases must start with a number:
```
Member must satisfy regular expression pattern: (?!^[0-9]+$)([a-zA-Z0-9-_]+)
```

@grosser 
@purohitatul 
@zendesk/cloudops 