### PR TITLE
run tests atomic so coverage is enforced per file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     env: $TASK=rubocop
     rvm: 2.4
 rvm:
-- 2.2
 - 2.3
 - 2.4
+matrix:
+  include:
+    - rvm: 2.2
+      script: bundle exec rake spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,12 @@ GEM
     aws-sigv4 (1.0.1)
     bump (0.5.4)
     diff-lcs (1.3)
+    forking_test_runner (1.1.0)
+      parallel_tests (>= 1.3.7)
     jmespath (1.3.1)
     parallel (1.12.0)
+    parallel_tests (2.16.0)
+      parallel
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -51,6 +55,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
+  forking_test_runner
   lambda_deployment!
   rspec
   rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,9 @@ require 'rubocop/rake_task'
 require 'bump/tasks'
 
 RuboCop::RakeTask.new
-RSpec::Core::RakeTask.new
-task default: %i[rubocop spec]
+
+task :atomic_spec do
+  sh 'bundle exec forking-test-runner spec --rspec --merge-coverage --quiet'
+end
+
+task default: %i[rubocop atomic_spec]

--- a/lambda_deployment.gemspec
+++ b/lambda_deployment.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'single_cov'
   s.add_development_dependency 'bump'
+  s.add_development_dependency 'forking_test_runner'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'single_cov'
 SingleCov.setup :rspec
 
 require 'lambda_deployment'
+require 'tempfile'
 
 module HelperMethods
   def create_temp_config(content)


### PR DESCRIPTION
... a bit funky and maybe too much ... but a fun experiment ...
previously the alias_name method had no test coverage in configuration_spec.rb ... but it did not break travis since the code was covered by deploy_spec ... but when running only configuration_spec it would fail ... so run tests in isolation ...

does not work on ruby 2.2 so making that separate