### PR TITLE
Deploy environment vars

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ LineLength:
   Max: 120
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
 
 Metrics/BlockLength:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     lambda_deployment (0.1.4)
       aws-sdk-core (~> 2)
+      dotenv (~> 2)
 
 GEM
   remote: https://rubygems.org/
@@ -14,6 +15,7 @@ GEM
     aws-sigv4 (1.0.1)
     bump (0.5.4)
     diff-lcs (1.3)
+    dotenv (2.2.1)
     forking_test_runner (1.1.0)
       parallel_tests (>= 1.3.7)
     jmespath (1.3.1)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ project: my-dev-lambda-name   # required: name of lambda function
 region: us-east-1             # optional: specify AWS region (will override $AWS_REGION)
 s3_bucket: my-test-bucket     # optional: specify s3 bucket (will override $LAMBDA_S3_BUCKET)
 s3_sse: AES256                # optional: set server side encryption on s3 objects (will override $LAMBDA_S3_SSE)
+environment:
+  FOO: bar                    # optional: set some env vars for your Lambda
 ```
 
 * *file_name* is a path relative to the configuration file

--- a/examples/lambda/lambda_deploy_dev.yml
+++ b/examples/lambda/lambda_deploy_dev.yml
@@ -4,3 +4,5 @@ file_name: example.zip     # required: zip or jar of lambda function and depende
 region: us-west-2          # optional: specify aws region (override $AWS_REGION)
 s3_bucket: my-test-bucket  # optional: specify s3 bucket (override $LAMBDA_S3_BUCKET)
 s3_sse: AES256             # optional: set server side encryption on s3 objects
+environment:
+  FOO: bar

--- a/lambda_deployment.gemspec
+++ b/lambda_deployment.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.executables = ['lambda_deploy']
 
   s.add_runtime_dependency 'aws-sdk-core', '~> 2'
+  s.add_runtime_dependency 'dotenv', '~> 2'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/lib/lambda_deployment/client.rb
+++ b/lib/lambda_deployment/client.rb
@@ -4,6 +4,10 @@ module LambdaDeployment
       @region = region
     end
 
+    def kms_client
+      @kms_client ||= Aws::KMS::Client.new(config)
+    end
+
     def lambda_client
       @lambda_client ||= Aws::Lambda::Client.new(config)
     end

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -2,7 +2,7 @@ require 'dotenv'
 
 module LambdaDeployment
   class Configuration
-    attr_reader :file_path, :project, :region, :s3_bucket, :s3_key, :s3_sse
+    attr_reader :kms_key_arn, :file_path, :project, :region, :s3_bucket, :s3_key, :s3_sse
 
     def load_config(config_file)
       config = YAML.load_file(config_file)
@@ -16,6 +16,7 @@ module LambdaDeployment
       @s3_sse = config.fetch('s3_sse', ENV.fetch('LAMBDA_S3_SSE', nil))
 
       @config_env = config.fetch('environment', {})
+      @kms_key_arn = config.fetch('kms_key_arn', ENV.fetch('LAMBDA_KMS_KEY_ARN', nil))
     end
 
     # lambda aliases must satisfy (?!^[0-9]+$)([a-zA-Z0-9-_]+)

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -27,7 +27,9 @@ module LambdaDeployment
     end
 
     def environment
-      @environment_cache ||= Dotenv.overload(*Dir.glob('.env*')).merge(@config_env)
+      @environment_cache ||= Dir.glob('.env*').reduce({}) do |cache, filename|
+        cache.merge Dotenv::Environment.new(filename)
+      end.merge(@config_env)
     end
 
     private

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -27,7 +27,7 @@ module LambdaDeployment
     end
 
     def environment
-      @environment_cache ||= @config_env.merge(Dotenv.overload(*Dir.glob('.env*')))
+      @environment_cache ||= Dotenv.overload(*Dir.glob('.env*')).merge(@config_env)
     end
 
     private

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -2,6 +2,25 @@ module LambdaDeployment
   class Configuration
     attr_reader :file_path, :project, :region, :s3_bucket, :s3_key, :s3_sse
 
+    # https://github.com/bkeepers/dotenv/blob/a47020f6c414e0a577680b324e61876a690d2200/lib/dotenv/parser.rb#L14
+    LINE_RE = /
+      \A
+      \s*
+      (?:export\s+)?    # optional export
+      ([\w\.]+)         # key
+      (?:\s*=\s*|:\s+?) # separator
+      (                 # optional value begin
+        '(?:\'|[^'])*'  #   single quoted value
+        |               #   or
+        "(?:\"|[^"])*"  #   double quoted value
+        |               #   or
+        [^#\n]+         #   unquoted value
+      )?                # value end
+      \s*
+      (?:\#.*)?         # optional comment
+      \z
+    /x
+
     def load_config(config_file)
       config = YAML.load_file(config_file)
       @project = config.fetch('project')
@@ -12,6 +31,8 @@ module LambdaDeployment
       @s3_bucket = config.fetch('s3_bucket', ENV.fetch('LAMBDA_S3_BUCKET', nil))
       @s3_key = s3_key_name(config.fetch('file_name'))
       @s3_sse = config.fetch('s3_sse', ENV.fetch('LAMBDA_S3_SSE', nil))
+
+      @config_env = config.fetch('environment', {})
     end
 
     # lambda aliases must satisfy (?!^[0-9]+$)([a-zA-Z0-9-_]+)
@@ -22,12 +43,28 @@ module LambdaDeployment
       tag
     end
 
+    def environment
+      @environment ||= calculate_environment_vars
+    end
+
     private
 
     def s3_key_name(file_name)
       basename = File.basename(file_name, '.*')
       extension = File.extname(file_name)
       "#{basename}-#{ENV.fetch('TAG', 'latest')}#{extension}"
+    end
+
+    def calculate_environment_vars
+      Dir.glob('.env.*') do |filename|
+        File.open(filename).each do |line|
+          if (match = line.match(LINE_RE))
+            key, value = match.captures
+            @config_env[key] = value.strip
+          end
+        end
+      end
+      @config_env
     end
   end
 end

--- a/lib/lambda_deployment/lambda/deploy.rb
+++ b/lib/lambda_deployment/lambda/deploy.rb
@@ -9,6 +9,7 @@ module LambdaDeployment
       def run
         upload_to_s3
         update_function_code
+        update_environment
         return unless @config.alias_name
         version = publish_version
         begin
@@ -34,6 +35,15 @@ module LambdaDeployment
           function_name: @config.project,
           s3_bucket: @config.s3_bucket,
           s3_key: @config.s3_key
+        )
+      end
+
+      def update_environment
+        @client.lambda_client.update_function_configuration(
+          function_name: @config.project,
+          environment: {
+            variables: @config.environment
+          }
         )
       end
 

--- a/lib/lambda_deployment/lambda/deploy.rb
+++ b/lib/lambda_deployment/lambda/deploy.rb
@@ -41,6 +41,7 @@ module LambdaDeployment
       def update_environment
         @client.lambda_client.update_function_configuration(
           function_name: @config.project,
+          kms_key_arn: '',
           environment: {
             variables: @config.environment
           }

--- a/spec/lambda_deployment/client_spec.rb
+++ b/spec/lambda_deployment/client_spec.rb
@@ -8,6 +8,10 @@ describe LambdaDeployment::Client do
 
   let(:client) { described_class.new('us-east-1') }
 
+  it 'builds a client for kms' do
+    expect(client.kms_client).to be_a(Aws::KMS::Client)
+  end
+
   it 'builds a client for lambda' do
     expect(client.lambda_client).to be_a(Aws::Lambda::Client)
   end

--- a/spec/lambda_deployment/configuration_spec.rb
+++ b/spec/lambda_deployment/configuration_spec.rb
@@ -37,6 +37,7 @@ describe LambdaDeployment::Configuration do
 
     it 'loads the environment variables' do
       expect(@config.environment).to eq('FOO' => 'bar')
+      expect(ENV['FOO']).to eq(nil)
     end
   end
 
@@ -96,6 +97,7 @@ describe LambdaDeployment::Configuration do
 
     it 'loads the environment from both YAML and .env' do
       expect(@config.environment).to eq('FOO' => 'bar', 'BAZ' => 'qux')
+      expect(ENV['FOO']).to eq(nil)
     end
   end
 

--- a/spec/lambda_deployment/configuration_spec.rb
+++ b/spec/lambda_deployment/configuration_spec.rb
@@ -34,6 +34,10 @@ describe LambdaDeployment::Configuration do
     it 'configures server side encryption' do
       expect(@config.s3_sse).to eq('AES256')
     end
+
+    it 'loads the environment variables' do
+      expect(@config.environment).to eq('FOO' => 'bar')
+    end
   end
 
   context 'it loads the configuration from env' do
@@ -76,6 +80,24 @@ describe LambdaDeployment::Configuration do
 
     it 'configures server side encryption' do
       expect(@config.s3_sse).to eq('AES256')
+    end
+  end
+
+  context 'it loads environment vars from .env files' do
+    before do
+      File.open('.env.test', 'w') do |file|
+        file.write 'BAZ=qux'
+      end
+      @config = described_class.new
+      @config.load_config('examples/lambda/lambda_deploy_dev.yml')
+    end
+
+    after do
+      File.delete '.env.test'
+    end
+
+    it 'loads the environment from both YAML and .env' do
+      expect(@config.environment).to eq('FOO' => 'bar', 'BAZ' => 'qux')
     end
   end
 

--- a/spec/lambda_deployment/configuration_spec.rb
+++ b/spec/lambda_deployment/configuration_spec.rb
@@ -85,9 +85,7 @@ describe LambdaDeployment::Configuration do
 
   context 'it loads environment vars from .env files' do
     before do
-      File.open('.env.test', 'w') do |file|
-        file.write 'BAZ=qux'
-      end
+      File.write '.env.test', 'BAZ=qux'
       @config = described_class.new
       @config.load_config('examples/lambda/lambda_deploy_dev.yml')
     end

--- a/spec/lambda_deployment/lambda/deploy_spec.rb
+++ b/spec/lambda_deployment/lambda/deploy_spec.rb
@@ -12,6 +12,7 @@ describe LambdaDeployment::Lambda::Deploy do
     it 'uploads a new version' do
       stub_s3_put('latest')
       stub_update_function('latest')
+      stub_update_function_configuration('FOO' => 'bar')
       described_class.new(@config).run
     end
   end
@@ -22,6 +23,7 @@ describe LambdaDeployment::Lambda::Deploy do
     before do
       @config = LambdaDeployment::Configuration.new
       @config.load_config('examples/lambda/lambda_deploy_dev.yml')
+      stub_update_function_configuration('FOO' => 'bar')
     end
 
     it 'uploads a new version and creates an alias' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,10 +50,11 @@ module HelperMethods
     ).and_return(nil)
   end
 
-  def stub_update_function_configuration(env)
+  def stub_update_function_configuration(env, key_arn = nil)
+    env.map { |k, v| env[k] = "#{v}-encoded" } if key_arn
     expect_any_instance_of(Aws::Lambda::Client).to receive(:update_function_configuration).with(
       function_name: 'lambda-deploy',
-      kms_key_arn: '',
+      kms_key_arn: key_arn,
       environment: { variables: env }
     ).and_return(nil)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,7 @@ module HelperMethods
   def stub_update_function_configuration(env)
     expect_any_instance_of(Aws::Lambda::Client).to receive(:update_function_configuration).with(
       function_name: 'lambda-deploy',
+      kms_key_arn: '',
       environment: { variables: env }
     ).and_return(nil)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,13 @@ module HelperMethods
     ).and_return(nil)
   end
 
+  def stub_update_function_configuration(env)
+    expect_any_instance_of(Aws::Lambda::Client).to receive(:update_function_configuration).with(
+      function_name: 'lambda-deploy',
+      environment: { variables: env }
+    ).and_return(nil)
+  end
+
   def with_env(env)
     old = ENV.to_h
     env.each { |k, v| ENV[k.to_s] = v }


### PR DESCRIPTION
During a deployment, Samson leaves `.env.something` files sprinkled in the root dir of the project, intending that these will be included in the eventually-deployed project. This adds that capability to this package. It :a: includes all variables in all `.env.*` files it finds, and :b: allows the user to include an `environment` hash in their YAML file. These two hashes are merged together, and deployed to the environment of the Lambda.

- [x] Read env vars from `.env.*`
- [x] Read env vars from YAML
- [x] Expose via `config.environment`
- [x] Send to AWS via `@client.lambda_client.update_function_configuration`
- [x] Encrypt some or all of the env vars using KMS
- [x] Tests

/cc @rbayerl 