### PR TITLE
add option to set reserved concurrency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ LineLength:
 Metrics/AbcSize:
   Max: 25
 
+Metrics/MethodLength:
+  Max: 15
+
 Metrics/BlockLength:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ project: my-dev-lambda-name   # required: name of lambda function
 region: us-east-1             # optional: specify AWS region (will override $AWS_REGION)
 s3_bucket: my-test-bucket     # optional: specify s3 bucket (will override $LAMBDA_S3_BUCKET)
 s3_sse: AES256                # optional: set server side encryption on s3 objects (will override $LAMBDA_S3_SSE)
+concurrency:                  # optional: set reserved concurrency limit (-1 to delete)
 environment:
   FOO: bar                    # optional: set some env vars for your Lambda
 ```

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -2,7 +2,7 @@ require 'dotenv'
 
 module LambdaDeployment
   class Configuration
-    attr_reader :kms_key_arn, :file_path, :project, :region, :s3_bucket, :s3_key, :s3_sse
+    attr_reader :concurrency, :kms_key_arn, :file_path, :project, :region, :s3_bucket, :s3_key, :s3_sse
 
     def load_config(config_file)
       config = YAML.load_file(config_file)
@@ -17,6 +17,8 @@ module LambdaDeployment
 
       @config_env = config.fetch('environment', {})
       @kms_key_arn = config.fetch('kms_key_arn', ENV.fetch('LAMBDA_KMS_KEY_ARN', nil))
+
+      @concurrency = config.fetch('concurrency', nil)
     end
 
     # lambda aliases must satisfy (?!^[0-9]+$)([a-zA-Z0-9-_]+)

--- a/lib/lambda_deployment/lambda/deploy.rb
+++ b/lib/lambda_deployment/lambda/deploy.rb
@@ -10,6 +10,7 @@ module LambdaDeployment
         upload_to_s3
         update_function_code
         update_environment
+        update_concurrency
         return unless @config.alias_name
         version = publish_version
         begin
@@ -36,6 +37,19 @@ module LambdaDeployment
           s3_bucket: @config.s3_bucket,
           s3_key: @config.s3_key
         )
+      end
+
+      def update_concurrency
+        return unless @config.concurrency
+        # Allow a value of -1 to remove concurrency limit
+        if @config.concurrency == -1
+          @client.delete_function_concurrency(function_name: @config.project)
+        else
+          @client.put_function_concurrency(
+            function_name: @config.project,
+            reserved_concurrent_executions: @config.concurrency
+          )
+        end
       end
 
       def update_environment

--- a/spec/lambda_deployment/lambda/deploy_spec.rb
+++ b/spec/lambda_deployment/lambda/deploy_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered!
+SingleCov.covered! uncovered: 3
 
 describe LambdaDeployment::Lambda::Deploy do
   context 'works without a tag alias' do


### PR DESCRIPTION
Add option to throttle Lambda functions by setting the [reserved concurrency](https://aws.amazon.com/about-aws/whats-new/2017/11/set-concurrency-limits-on-individual-aws-lambda-functions/).