### PR TITLE
Deploy from s3 directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
 *.rbc
 .bundle
+.byebug_history
 */Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     bump (0.6.0)
+    byebug (10.0.2)
     diff-lcs (1.3)
     dotenv (2.5.0)
     forking_test_runner (1.2.0)
@@ -72,6 +73,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
+  byebug
   forking_test_runner
   lambda_deployment!
   rake
@@ -80,4 +82,4 @@ DEPENDENCIES
   single_cov
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ lambda_deploy [-c path/to/configuration.yml] deploy|release
 ```
 
 ### Deploy action
-The deploy action will upload the function to S3, and update the function to
-use the new code. If the environmental variable `TAG` is set it will also
+The deploy action will optionally upload the function to S3 if a zip/jar file is configured.
+If no file is provided then the script will assume that it was already uploaded to S3 by some
+other mean (GCR build for instance) and proceed with the update. It will then update the
+function to use the new code. If the environmental variable `TAG` is set it will also
 create a version and link that version to an alias named `TAG`.
 
 ### Release action
@@ -71,7 +73,8 @@ environment:
   FOO: bar                    # optional: set some env vars for your Lambda
 ```
 
-* *file_name* is a path relative to the configuration file
+* *file_name* is the key that will be used to store the code archive on S3. If the code needs to be uploaded
+as part of the deploy process, the file_name needs to be the path relative to the configuration file
 * *project* must match the function name in the AWS console (the last value in
 the following example):
 ```

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ lambda_deploy [-c path/to/configuration.yml] deploy|release
 ```
 
 ### Deploy action
-The deploy action will optionally upload the function to S3 if a zip/jar file is configured.
-If no file is provided then the script will assume that it was already uploaded to S3 by some
-other mean (GCR build for instance) and proceed with the update. It will then update the
-function to use the new code. If the environmental variable `TAG` is set it will also
+The deploy action will upload the function to S3, unless the `SKIP_UPLOAD`
+environment variable is set to `true`. It will then update the function to
+use the new code. If the environmental variable `TAG` is set it will also
 create a version and link that version to an alias named `TAG`.
 
 ### Release action
@@ -73,8 +72,9 @@ environment:
   FOO: bar                    # optional: set some env vars for your Lambda
 ```
 
-* *file_name* is the key that will be used to store the code archive on S3. If the code needs to be uploaded
-as part of the deploy process, the file_name needs to be the path relative to the configuration file
+* *file_name* is the file_name needs to be the path relative to the configuration file.
+It is also used, together with the TAG to generate the S3 key, not that the path, if any will not
+be part of the key. So 'dist/lambda.zip' will result in a S3 key such as 'lambda-v3.zip'.
 * *project* must match the function name in the AWS console (the last value in
 the following example):
 ```

--- a/examples/lambda-without-zip/lambda_deploy.yml
+++ b/examples/lambda-without-zip/lambda_deploy.yml
@@ -1,0 +1,3 @@
+# example of minimal default file for use with samson
+project: lambda-deploy  # required: name of lambda function
+file_name: example.zip  # required: zip or jar of lambda function and dependencies

--- a/examples/lambda-without-zip/lambda_deploy_dev.yml
+++ b/examples/lambda-without-zip/lambda_deploy_dev.yml
@@ -1,0 +1,8 @@
+# example of file for local use in the dev account
+project: lambda-deploy     # required: name of lambda function
+file_name: example.zip     # required: zip or jar of lambda function and dependencies
+region: us-west-2          # optional: specify aws region (override $AWS_REGION)
+s3_bucket: my-test-bucket  # optional: specify s3 bucket (override $LAMBDA_S3_BUCKET)
+s3_sse: AES256             # optional: set server side encryption on s3 objects
+environment:
+  FOO: bar

--- a/lambda_deployment.gemspec
+++ b/lambda_deployment.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'forking_test_runner'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'byebug'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'single_cov'
 end

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -8,12 +8,13 @@ module LambdaDeployment
       config = YAML.load_file(config_file)
       @project = config.fetch('project')
       @region = config.fetch('region', ENV.fetch('AWS_REGION', nil))
-      @file_path = File.expand_path(config.fetch('file_name'), File.dirname(config_file))
-      raise "File not found: #{@file_path}" unless File.exist?(@file_path)
 
-      @s3_bucket = config.fetch('s3_bucket', ENV.fetch('LAMBDA_S3_BUCKET', nil))
       @s3_key = s3_key_name(config.fetch('file_name'))
+      @s3_bucket = config.fetch('s3_bucket', ENV.fetch('LAMBDA_S3_BUCKET', nil))
       @s3_sse = config.fetch('s3_sse', ENV.fetch('LAMBDA_S3_SSE', nil))
+
+      @file_path = File.expand_path(config.fetch('file_name'), File.dirname(config_file))
+      @file_path = nil unless File.exist?(@file_path)
 
       @config_env = config.fetch('environment', {})
       @kms_key_arn = config.fetch('kms_key_arn', ENV.fetch('LAMBDA_KMS_KEY_ARN', nil))

--- a/lib/lambda_deployment/configuration.rb
+++ b/lib/lambda_deployment/configuration.rb
@@ -2,10 +2,11 @@ require 'dotenv'
 
 module LambdaDeployment
   class Configuration
-    attr_reader :concurrency, :kms_key_arn, :file_path, :project, :region, :s3_bucket, :s3_key, :s3_sse
+    attr_reader :concurrency, :kms_key_arn, :file_path, :project, :region, :s3_bucket, :s3_key, :s3_sse, :skip_upload
 
     def load_config(config_file)
       config = YAML.load_file(config_file)
+      @skip_upload = ENV.fetch('SKIP_UPLOAD', 'false') == 'true'
       @project = config.fetch('project')
       @region = config.fetch('region', ENV.fetch('AWS_REGION', nil))
 
@@ -13,8 +14,10 @@ module LambdaDeployment
       @s3_bucket = config.fetch('s3_bucket', ENV.fetch('LAMBDA_S3_BUCKET', nil))
       @s3_sse = config.fetch('s3_sse', ENV.fetch('LAMBDA_S3_SSE', nil))
 
-      @file_path = File.expand_path(config.fetch('file_name'), File.dirname(config_file))
-      @file_path = nil unless File.exist?(@file_path)
+      unless @skip_upload
+        @file_path = File.expand_path(config.fetch('file_name'), File.dirname(config_file))
+        raise "File not found: #{@file_path}" unless File.exist?(@file_path)
+      end
 
       @config_env = config.fetch('environment', {})
       @kms_key_arn = config.fetch('kms_key_arn', ENV.fetch('LAMBDA_KMS_KEY_ARN', nil))

--- a/lib/lambda_deployment/lambda/deploy.rb
+++ b/lib/lambda_deployment/lambda/deploy.rb
@@ -47,7 +47,7 @@ module LambdaDeployment
       end
 
       def update_function_code
-        raise ArchiveMissingError unless code_exists_on_s3?
+        raise ArchiveMissingError.new("Could not find an archive on #{@config.s3_bucket} with the key #{@config.s3_key}") unless code_exists_on_s3?
 
         @client.lambda_client.update_function_code(
           function_name: @config.project,

--- a/lib/lambda_deployment/lambda/deploy.rb
+++ b/lib/lambda_deployment/lambda/deploy.rb
@@ -24,12 +24,8 @@ module LambdaDeployment
 
       private
 
-      def upload_code_to_s3?
-        @config.file_path && File.exist?(@config.file_path)
-      end
-
       def upload_to_s3
-        return unless upload_code_to_s3?
+        return if @config.skip_upload
 
         @client.s3_client.put_object(
           body: File.read(@config.file_path),

--- a/spec/lambda_deployment/lambda/deploy_spec.rb
+++ b/spec/lambda_deployment/lambda/deploy_spec.rb
@@ -119,12 +119,15 @@ describe LambdaDeployment::Lambda::Deploy do
   end
 
   context 'without an archive to upload' do
+    around { |t| with_env(SKIP_UPLOAD: 'true', &t) }
+
     before do
       @config = LambdaDeployment::Configuration.new
       @config.load_config('examples/lambda-without-zip/lambda_deploy_dev.yml')
     end
 
     it 'skips the upload and proceeds' do
+      expect_any_instance_of(Aws::S3::Client).not_to receive(:put_object)
       stub_head_object('latest')
       stub_update_function('latest')
       stub_update_function_configuration('FOO' => 'bar')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,13 @@ module HelperMethods
     ).and_return(nil)
   end
 
+  def stub_head_object(version)
+    expect_any_instance_of(Aws::S3::Client).to receive(:head_object).with(
+      bucket: 'my-test-bucket',
+      key: "example-#{version}.zip"
+    ).and_return(nil)
+  end
+
   def stub_update_function_configuration(env, key_arn = nil)
     env.map { |k, v| env[k] = "#{v}-encoded" } if key_arn
     expect_any_instance_of(Aws::Lambda::Client).to receive(:update_function_configuration).with(


### PR DESCRIPTION
So it is possible to use another process (such as GCR builds) to upload the archive to S3 and have the deploy script pick up from there.